### PR TITLE
FIX: silent fails with release build, and clean spaghetti code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ copypasta = "0.10.1" # copy to clipboard
 
 winapi = { version = "0.3.9", features = ["wincon"] }
 windows = { version = "0.56.0", features = ["Win32", "Win32_UI", "Win32_UI_WindowsAndMessaging"]}
+homedir = "0.3.4"
 
 [build-dependencies]
 winres = "0.1" # give the exe an icon

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,10 @@
 use clap::Parser;
 use std::fs::File;
+use std::fs;
 use std::io::{Read, Write};
 use std::{env, path::PathBuf, process::Command};
+use crate::portable;
+use homedir;
 
 /// Smoothen up your gameplay footage with Smoothie, yum!
 #[derive(Parser, Debug, Clone)]
@@ -193,25 +196,7 @@ If you'd like help, take a screenshot of this message and your recipe and come o
         .expect("Could not get directory of directory's executable??");
     
 
-    // Linux stuff
-    #[cfg(not(target_os = "windows"))] {
-        home_dir = env::home_dir().expect("How do you not have a user dir?");
-        config_path = home_dir.join(".config/smoothie-rs");
-        if !config_path.exists() {
-            panic!("expected folder @ {}", config_path.display());
-        }
-        local_path = home_dir.join(".local/share");
-        local_path.push("smoothie-rs");
-        if !local_path.exists() {
-            panic!("expected folder @ {}", local_path.display());
-        }
-    
-    }
-    #[cfg(target_os = "windows")]
-    let mut last_args = current_exe_path_dir.join("last_args.txt");
-
-    #[cfg(not(target_os = "windows"))]
-    let mut last_args = local_path.join("last_args.txt");
+    let mut last_args = portable::get_last_args_path();
 
     if !last_args.exists() {
         if File::create(&last_args).is_err() {
@@ -221,10 +206,7 @@ If you'd like help, take a screenshot of this message and your recipe and come o
 
     match first_arg.as_ref() {
         "enc" | "encoding" | "presets" | "encpresets" | "macros" => {
-            #[cfg(target_os = "windows")]
-            let presets_path = current_exe_path.join("..").join("encoding_presets.ini");
-            #[cfg(not(target_os = "windows"))]
-            let presets_path = config_path.join("encoding_presets.ini");
+            let presets_path = portable::get_encoding_presets_path();
             if !presets_path.exists() {
                 panic!(
                     "Could not find encoding presets (expected at {})",
@@ -244,7 +226,7 @@ If you'd like help, take a screenshot of this message and your recipe and come o
             }
         }
         "def" | "default" | "defaults" => {
-            let presets_path = current_exe_path.join("..").join("defaults.ini");
+            let presets_path = portable::get_defaults_path();
 
             if !presets_path.exists() {
                 panic!(
@@ -266,10 +248,7 @@ If you'd like help, take a screenshot of this message and your recipe and come o
             }
         }
         "rc" | "recipe" | "conf" | "config" => {
-            #[cfg(target_os = "windows")]
-            let ini_path = current_exe_path.join("..").join("recipe.ini");
-            #[cfg(not(target_os = "windows"))]
-            let ini_path = config_path.join("recipe.ini");
+            let ini_path = portable::get_recipe_path();
             if !ini_path.exists() {
                 panic!("Could not find recipe at {}", ini_path.display())
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ mod smgui;
 // mod ffpb;
 // mod ffpb2;
 mod parse;
+mod portable;
 mod recipe;
 mod render;
 mod utils;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,11 +1,11 @@
 use crate::cli::Arguments;
+use crate::portable;
 use crate::recipe::{parse_recipe, Recipe};
 use crate::verb;
 use color_eyre::owo_colors::OwoColorize;
 use colored::Colorize;
 use serde::Deserialize;
 use std::env;
-use std::env::current_exe;
 use std::time::Duration;
 use ureq::{Agent, Error as uReqError};
 
@@ -17,31 +17,13 @@ pub fn parse_encoding_args(args: &Arguments, rc: &Recipe) -> String {
     };
 
     let mut enc_arg_presets: Recipe = Recipe::new();
-    #[cfg(target_os = "windows")]
     parse_recipe(
-        current_exe()
-            .expect("Failed getting exe path")
-            .parent()
-            .expect("Failed getting exe parent path")
-            .parent()
-            .unwrap()
-            .join("encoding_presets.ini"),
+        portable::get_encoding_presets_path(),
         None,
         &mut enc_arg_presets,
         &mut None,
         false,
     );
-    #[cfg(not(target_os = "windows"))]
-    parse_recipe(
-        env::home_dir()
-            .expect("YOU DONT HAVE HOME DIR??????")
-            .join(".config/smoothie-rs/encoding_presets.ini"),
-        None,
-        &mut enc_arg_presets,
-        &mut None,
-        false,
-    );
-    // dbg!(&enc_arg_presets);
 
     let mut codec = String::new(); // e.g H264, H265
     let mut ret = String::new();

--- a/src/portable.rs
+++ b/src/portable.rs
@@ -1,0 +1,82 @@
+use std::{env, path::PathBuf, fs};
+use homedir;
+
+const DEFAULT_RECIPE: &str = include_str!("../target/recipe.ini");
+const DEFAULT_ENCODING_PRESETS: &str = include_str!("../target/encoding_presets.ini");
+
+fn get_target_path() -> PathBuf {
+    let current_exe = env::current_exe().expect("Could not determine exe");
+    let target_dir = current_exe.parent()
+        .expect("Could not get directory of executable")
+        .parent()
+        .expect("Could not get directory of directory's executable??");
+    return target_dir.to_path_buf();
+}
+
+fn is_portable() -> bool {
+    let portable = get_target_path().join("linux-portable-enable");
+    return portable.exists();
+}
+
+pub fn get_config_path() -> PathBuf {
+    let config_path: PathBuf;
+    
+    if cfg!(target_os = "windows") || is_portable() {
+        config_path = get_target_path();
+    } else {
+        let home_dir = homedir::my_home()
+            .unwrap()
+            .expect("How do you not have a user dir?");
+        config_path = home_dir.join(".config/smoothie-rs");
+        if !config_path.exists() {
+            fs::create_dir_all(&config_path)
+                .expect("Failed to create config folder");
+        }
+    } 
+
+    return config_path;
+}
+
+pub fn get_recipe_path() -> PathBuf {
+    let recipe_path = get_config_path().join("recipe.ini");
+    if !recipe_path.exists() {
+        fs::write(&recipe_path, DEFAULT_RECIPE).unwrap();
+    }
+    return recipe_path;
+}
+
+pub fn get_encoding_presets_path() -> PathBuf {
+    let encoding_presets_path = get_config_path().join("encoding_presets.ini");
+    if !encoding_presets_path.exists() {
+        fs::write(&encoding_presets_path, DEFAULT_ENCODING_PRESETS).unwrap();
+    }
+    return encoding_presets_path;
+}
+
+pub fn get_defaults_path() -> PathBuf {
+    return get_target_path().join("defaults.ini");
+}
+
+pub fn get_last_args_path() -> PathBuf {
+    let last_args: PathBuf;
+
+    if cfg!(target_os = "windows") || is_portable() {
+        last_args = get_target_path()
+            .join("last_args.txt");
+    } else {
+        let home_dir = homedir::my_home()
+            .unwrap()
+            .expect("How do you not have a user dir?");
+        last_args = home_dir.join(".local/share/smoothie-rs/last_args.txt");
+        if !last_args.exists() {
+            fs::create_dir_all(
+                last_args
+                .parent()
+                .unwrap())
+                .expect("Failed to create local folder"
+                );
+        }
+    }
+
+    return last_args;
+}

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -1,6 +1,7 @@
 use crate::cli::Arguments;
 use crate::verb;
 use crate::{NO, YES};
+use crate::portable;
 use indexmap::map::Entry;
 use indexmap::map::IndexMap;
 use indexmap::map::Keys;
@@ -394,36 +395,10 @@ pub fn get_recipe(args: &mut Arguments) -> (Recipe, WidgetMetadata) {
         None => panic!("Could not resolve Smoothie's binary directory `{exe:?}`"),
     };
 
-    let home_dir: PathBuf;
-    let config_path: PathBuf = Default::default();
-    let local_path: PathBuf = Default::default();
-    let cur_dir_sc: PathBuf = Default::default();
-
-    let mut config_path: PathBuf = Default::default();
-    let mut local_path: PathBuf = Default::default();
-
-    #[cfg(not(target_os = "windows"))]
-    {
-        home_dir = env::home_dir().expect("How do you not have a user dir?");
-        config_path = home_dir.join(".config/smoothie-rs");
-        if !config_path.exists() {
-            panic!("ERROR: expected folder not found @ {}", config_path.display());
-        }
-
-        local_path = home_dir.join(".local/share/smoothie-rs");
-        if !local_path.exists() {
-            panic!("ERROR: expected folder not found @ {}", local_path.display());
-        }
-    }
-
     let rc_path = if PathBuf::from(&args.recipe).exists() {
         PathBuf::from(&args.recipe)
     } else {
-        let cur_dir_rc = if cfg!(target_os = "windows") {
-            bin_dir.join(&args.recipe)
-        } else {
-            config_path.join(&args.recipe)
-        };
+        let cur_dir_rc = portable::get_recipe_path();
         if !cur_dir_rc.exists() {
             panic!(
                 "Recipe filepath does not exist (expected at {})",


### PR DESCRIPTION
Fixed: https://discord.com/channels/774315187183288411/1326869462150025237
Added linux portable mode, (You can enable it by creating `target/linux-portable-enable`)
Cleaned up spaghetti code for getting files(`recipe.ini`, `encoding_presets.ini`, `defaults.ini`) from `target/` by adding functions to get them in `src/portable.rs`